### PR TITLE
Rectif titres des pages

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Clients</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Contact</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Accueil</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 

--- a/liens.html
+++ b/liens.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Liens utiles</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	

--- a/services.html
+++ b/services.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Services</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	

--- a/services_amgt.html
+++ b/services_amgt.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Services - Aménagements</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 

--- a/services_foncier.html
+++ b/services_foncier.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Services - Foncier</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 

--- a/services_moe.html
+++ b/services_moe.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Services - Maîtrise d'oeuvre</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	

--- a/services_txspec.html
+++ b/services_txspec.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Géotlandes - Template</title>
+	<title>Géotlandes - Services - Travaux spécifiques</title>
 	<meta name="description" content="Cabinet de géomètre expert" />
 	<meta name="keywords" content="" />
 	


### PR DESCRIPTION
Les titres étaient restés en "Template" lors de la mise à jour de la barre de navigation.